### PR TITLE
Use Ix1/Ix2 instead of Ix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ lapack = "0.11.1"
 num-traits = "0.1.36"
 
 [dependencies.ndarray]
-version = "0.6.9"
+version = "0.7"
 features = ["blas"]
 
 [dev-dependencies]
 rand = "0.3.14"
-ndarray-rand = "0.2.0"
+ndarray-rand = "0.3"

--- a/src/hermite.rs
+++ b/src/hermite.rs
@@ -1,7 +1,6 @@
 //! Define trait for Hermite matrices
 
-use ndarray::prelude::*;
-use ndarray::LinalgScalar;
+use ndarray::{Ix2, Array, LinalgScalar};
 use num_traits::float::Float;
 
 use matrix::Matrix;
@@ -21,7 +20,7 @@ pub trait HermiteMatrix: SquareMatrix + Matrix {
     fn ssqrt(self) -> Result<Self, LinalgError>;
 }
 
-impl<A> HermiteMatrix for Array<A, (Ix, Ix)>
+impl<A> HermiteMatrix for Array<A, Ix2>
     where A: ImplQR + ImplSVD + ImplNorm + ImplSolve + ImplEigh + LinalgScalar + Float
 {
     fn eigh(self) -> Result<(Self::Vector, Self), LinalgError> {

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -46,7 +46,7 @@ impl<A> Matrix for Array<A, Ix2>
     where A: ImplQR + ImplSVD + ImplNorm + ImplSolve + LinalgScalar + Debug
 {
     type Scalar = A;
-    type Vector = Array<A, Ix>;
+    type Vector = Array<A, Ix1>;
     type Permutator = Vec<i32>;
 
     fn size(&self) -> (usize, usize) {

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -1,8 +1,7 @@
 //! Define trait for general matrix
 
 use std::cmp::min;
-use ndarray::prelude::*;
-use ndarray::LinalgScalar;
+use ndarray::{Ix1, Ix2, Array, Axis, LinalgScalar};
 
 use error::LapackError;
 use qr::ImplQR;
@@ -27,11 +26,11 @@ pub trait Matrix: Sized {
     fn qr(self) -> Result<(Self, Self), LapackError>;
 }
 
-impl<A> Matrix for Array<A, (Ix, Ix)>
+impl<A> Matrix for Array<A, Ix2>
     where A: ImplQR + ImplSVD + ImplNorm + LinalgScalar
 {
     type Scalar = A;
-    type Vector = Array<A, Ix>;
+    type Vector = Array<A, Ix1>;
     fn size(&self) -> (usize, usize) {
         (self.rows(), self.cols())
     }

--- a/src/square.rs
+++ b/src/square.rs
@@ -1,7 +1,6 @@
 //! Define trait for Hermite matrices
 
-use ndarray::prelude::*;
-use ndarray::LinalgScalar;
+use ndarray::{Ix2, Array, LinalgScalar};
 use num_traits::float::Float;
 
 use matrix::Matrix;
@@ -37,7 +36,7 @@ pub trait SquareMatrix: Matrix {
     }
 }
 
-impl<A> SquareMatrix for Array<A, (Ix, Ix)>
+impl<A> SquareMatrix for Array<A, Ix2>
     where A: ImplQR + ImplNorm + ImplSVD + ImplSolve + LinalgScalar + Float
 {
     fn inv(self) -> Result<Self, LinalgError> {

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,7 +1,6 @@
 //! Define trait for vectors
 
-use ndarray::prelude::*;
-use ndarray::LinalgScalar;
+use ndarray::{LinalgScalar, Array, Ix1};
 use num_traits::float::Float;
 
 /// Methods for vectors
@@ -11,7 +10,7 @@ pub trait Vector {
     fn norm(&self) -> Self::Scalar;
 }
 
-impl<A: Float + LinalgScalar> Vector for Array<A, Ix> {
+impl<A: Float + LinalgScalar> Vector for Array<A, Ix1> {
     type Scalar = A;
     fn norm(&self) -> Self::Scalar {
         self.dot(&self).sqrt()

--- a/tests/cholesky.rs
+++ b/tests/cholesky.rs
@@ -9,7 +9,7 @@ use ndarray::prelude::*;
 use ndarray_linalg::prelude::*;
 use ndarray_rand::RandomExt;
 
-fn all_close(a: Array<f64, (Ix, Ix)>, b: Array<f64, (Ix, Ix)>) {
+fn all_close(a: Array<f64, Ix2>, b: Array<f64, Ix2>) {
     if !a.all_close(&b, 1.0e-7) {
         panic!("\nTwo matrices are not equal:\na = \n{:?}\nb = \n{:?}\n",
                a,

--- a/tests/inv.rs
+++ b/tests/inv.rs
@@ -9,7 +9,7 @@ use ndarray_linalg::prelude::*;
 use rand::distributions::*;
 use ndarray_rand::RandomExt;
 
-fn all_close(a: Array<f64, (Ix, Ix)>, b: Array<f64, (Ix, Ix)>) {
+fn all_close(a: Array<f64, Ix2>, b: Array<f64, Ix2>) {
     if !a.all_close(&b, 1.0e-7) {
         panic!("\nTwo matrices are not equal:\na = \n{:?}\nb = \n{:?}\n",
                a,

--- a/tests/lu.rs
+++ b/tests/lu.rs
@@ -9,7 +9,7 @@ use ndarray_linalg::prelude::*;
 use rand::distributions::*;
 use ndarray_rand::RandomExt;
 
-fn all_close(a: Array<f64, (Ix, Ix)>, b: Array<f64, (Ix, Ix)>) {
+fn all_close(a: Array<f64, Ix2>, b: Array<f64, Ix2>) {
     if !a.all_close(&b, 1.0e-7) {
         panic!("\nTwo matrices are not equal:\na = \n{:?}\nb = \n{:?}\n",
                a,
@@ -68,7 +68,7 @@ test_permutate_t!(permutate_4x3_t,
                   &[[1., 4., 7., 10.], [2., 5., 8., 11.], [3., 6., 9., 12.]],
                   &[[10., 11., 12.], [4., 5., 6.], [7., 8., 9.], [1., 2., 3.]]);
 
-fn test_lu(a: Array<f64, (Ix, Ix)>) {
+fn test_lu(a: Array<f64, Ix2>) {
     println!("a = \n{:?}", &a);
     let (p, l, u) = a.clone().lu().unwrap();
     println!("P = \n{:?}", &p);

--- a/tests/qr.rs
+++ b/tests/qr.rs
@@ -9,7 +9,7 @@ use ndarray_linalg::prelude::*;
 use rand::distributions::*;
 use ndarray_rand::RandomExt;
 
-fn all_close(a: Array<f64, (Ix, Ix)>, b: Array<f64, (Ix, Ix)>) {
+fn all_close(a: Array<f64, Ix2>, b: Array<f64, Ix2>) {
     if !a.all_close(&b, 1.0e-7) {
         panic!("\nTwo matrices are not equal:\na = \n{:?}\nb = \n{:?}\n",
                a,

--- a/tests/ssqrt.rs
+++ b/tests/ssqrt.rs
@@ -9,7 +9,7 @@ use ndarray::prelude::*;
 use ndarray_linalg::prelude::*;
 use ndarray_rand::RandomExt;
 
-fn all_close(a: &Array<f64, (Ix, Ix)>, b: &Array<f64, (Ix, Ix)>) {
+fn all_close(a: &Array<f64, Ix2>, b: &Array<f64, Ix2>) {
     if !a.all_close(b, 1.0e-7) {
         panic!("\nTwo matrices are not equal:\na = \n{:?}\nb = \n{:?}\n",
                a,

--- a/tests/svd.rs
+++ b/tests/svd.rs
@@ -10,7 +10,7 @@ use ndarray_linalg::prelude::*;
 use rand::distributions::*;
 use ndarray_rand::RandomExt;
 
-fn all_close(a: Array<f64, (Ix, Ix)>, b: Array<f64, (Ix, Ix)>) {
+fn all_close(a: Array<f64, Ix2>, b: Array<f64, Ix2>) {
     if !a.all_close(&b, 1.0e-7) {
         panic!("\nTwo matrices are not equal:\na = \n{:?}\nb = \n{:?}\n",
                a,


### PR DESCRIPTION
`Ix1`, `Ix2` are not belongs to `ndarray::prelude`, while `Ix` does.