### PR TITLE
Refactor solve

### DIFF
--- a/examples/solve.rs
+++ b/examples/solve.rs
@@ -1,0 +1,21 @@
+
+extern crate ndarray;
+extern crate ndarray_linalg;
+
+use ndarray::*;
+use ndarray_linalg::*;
+
+// Solve `Ax=b` for many b with fixed A
+fn factorize() -> Result<(), error::LinalgError> {
+    let a: Array2<f64> = random((3, 3));
+    let f = a.factorize_into()?; // LU factorize A (A is consumed)
+    for _ in 0..10 {
+        let b: Array1<f64> = random(3);
+        let x = f.solve(Transpose::No, b)?; // solve Ax=b using factorized L, U
+    }
+    Ok(())
+}
+
+fn main() {
+    factorize().unwrap();
+}

--- a/src/solve.rs
+++ b/src/solve.rs
@@ -75,14 +75,13 @@ where
     }
 }
 
-impl<A, Si, So> Factorize<So> for ArrayBase<Si, Ix2>
+impl<A, Si> Factorize<OwnedRepr<A>> for ArrayBase<Si, Ix2>
 where
     A: Scalar,
     Si: Data<Elem = A>,
-    So: DataOwned<Elem = A> + DataMut,
 {
-    fn factorize(&self) -> Result<Factorized<So>> {
-        let mut a: ArrayBase<So, Ix2> = replicate(self);
+    fn factorize(&self) -> Result<Factorized<OwnedRepr<A>>> {
+        let mut a: Array2<A> = replicate(self);
         let ipiv = unsafe { A::lu(a.layout()?, a.as_allocated_mut()?)? };
         Ok(Factorized { a: a, ipiv: ipiv })
     }


### PR DESCRIPTION
- Add example `examples/solve.rs`
- Remove generic Repr `So: Data`  from Factorize since current code let user to write the type explicitly.
- Clean up before implementing `solveh` #65 
