### PR TITLE
Use static link for OpenBLAS/Netlib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,13 @@ keywords      = ["ndarray", "lapack", "matrix"]
 license       = "MIT"
 
 [features]
-default  = ["openblas"]
-openblas = ["lapack/openblas", "openblas-src"]
-netlib   = ["lapack/netlib", "netlib-src"]
+default  = ["openblas-static"]
+openblas-shared = ["lapack/openblas"]
+openblas-static = ["lapack/openblas", "openblas-src/static"]
+openblas-system = ["lapack/openblas", "openblas-src/system"]
+netlib-shared   = ["lapack/netlib"]
+netlib-static   = ["lapack/netlib", "netlib-src/static"]
+netlib-system   = ["lapack/netlib", "netlib-src/system"]
 
 [dependencies]
 rand = "0.3"
@@ -33,11 +37,9 @@ default-features = false
 [dependencies.openblas-src]
 version = "0.5.3"
 default-features = false
-features = ["static"]
 optional = true
 
 [dependencies.netlib-src]
 version = "0.7.0"
 default-features = false
-features = ["static"]
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ license       = "MIT"
 
 [features]
 default  = ["openblas"]
-openblas = ["lapack/openblas"]
-netlib   = ["lapack/netlib"]
+openblas = ["lapack/openblas", "openblas-src"]
+netlib   = ["lapack/netlib", "netlib-src"]
 
 [dependencies]
 rand = "0.3"
@@ -20,5 +20,24 @@ derive-new = "0.4"
 enum-error-derive = "0.1"
 num-traits  = "0.1"
 num-complex = "0.1"
-ndarray = { version = "0.9",  default-features = false, features = ["blas"] }
-lapack  = { version = "0.13", default-features = false }
+
+[dependencies.ndarray]
+version = "0.9"
+default-features = false
+features = ["blas"]
+
+[dependencies.lapack]
+version = "0.13"
+default-features = false
+
+[dependencies.openblas-src]
+version = "0.5.3"
+default-features = false
+features = ["static"]
+optional = true
+
+[dependencies.netlib-src]
+version = "0.7.0"
+default-features = false
+features = ["static"]
+optional = true

--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ Dependencies
 
 and more (See Cargo.toml).
 
+Feature flags
+--------------
+
+- OpenBLAS
+  - `openblas-static`: use OpenBLAS with static link (default)
+  - `openblas-shared`: use OpenBLAS with shared link
+  - `openblas-system`: use system OpenBLAS (experimental)
+- Netlib
+  - `netlib-static`: use Netlib with static link (default)
+  - `netlib-shared`: use Netlib with shared link
+  - `netlib-system`: use system Netlib (experimental)
+
 Examples
 ---------
 See [examples](https://github.com/termoshtt/ndarray-linalg/tree/master/examples) directory.

--- a/wercker.yml
+++ b/wercker.yml
@@ -4,10 +4,10 @@ test-openblas:
   steps:
     - script:
       name: test OpenBLAS backend
-      code: cargo test --no-default-features --features=openblas
+      code: cargo test --no-default-features --features=openblas-static
 
 test-netlib:
   steps:
     - script:
       name: test NetLib backend
-      code: cargo test --no-default-features --features=netlib
+      code: cargo test --no-default-features --features=netlib-static


### PR DESCRIPTION
There is little merit to use shared linked libraries for recent most HPC applications.