### PR TITLE
Rename *_mut to *_inplace to match ndarray

### DIFF
--- a/src/cholesky.rs
+++ b/src/cholesky.rs
@@ -159,7 +159,7 @@ where
     A: Scalar,
     S: Data<Elem = A>,
 {
-    fn solvec_mut<'a, Sb>(&self, b: &'a mut ArrayBase<Sb, Ix1>) -> Result<&'a mut ArrayBase<Sb, Ix1>>
+    fn solvec_inplace<'a, Sb>(&self, b: &'a mut ArrayBase<Sb, Ix1>) -> Result<&'a mut ArrayBase<Sb, Ix1>>
     where
         Sb: DataMut<Elem = A>,
     {
@@ -205,7 +205,7 @@ pub trait CholeskyInto {
 }
 
 /// Cholesky decomposition of Hermitian (or real symmetric) positive definite mutable reference of matrix
-pub trait CholeskyMut {
+pub trait CholeskyInplace {
     /// Computes the Cholesky decomposition of the Hermitian (or real
     /// symmetric) positive definite matrix, writing the result (`L` or `U`
     /// according to the argument) to `self` and returning it.
@@ -214,7 +214,7 @@ pub trait CholeskyMut {
     /// U^H * U` using the upper triangular portion of `A` and writes `U`.
     /// Otherwise, if the argument is `UPLO::Lower`, computes the decomposition
     /// `A = L * L^H` using the lower triangular portion of `A` and writes `L`.
-    fn cholesky_mut(&mut self, UPLO) -> Result<&mut Self>;
+    fn cholesky_inplace(&mut self, UPLO) -> Result<&mut Self>;
 }
 
 impl<A, S> Cholesky for ArrayBase<S, Ix2>
@@ -238,17 +238,17 @@ where
     type Output = Self;
 
     fn cholesky_into(mut self, uplo: UPLO) -> Result<Self> {
-        self.cholesky_mut(uplo)?;
+        self.cholesky_inplace(uplo)?;
         Ok(self)
     }
 }
 
-impl<A, S> CholeskyMut for ArrayBase<S, Ix2>
+impl<A, S> CholeskyInplace for ArrayBase<S, Ix2>
 where
     A: Scalar,
     S: DataMut<Elem = A>,
 {
-    fn cholesky_mut(&mut self, uplo: UPLO) -> Result<&mut Self> {
+    fn cholesky_inplace(&mut self, uplo: UPLO) -> Result<&mut Self> {
         unsafe { A::cholesky(self.square_layout()?, uplo, self.as_allocated_mut()?)? };
         Ok(self.into_triangular(uplo))
     }
@@ -314,21 +314,21 @@ pub trait CholeskySolve<A: Scalar> {
     /// the argument, and `x` is the successful result.
     fn solvec<S: Data<Elem = A>>(&self, b: &ArrayBase<S, Ix1>) -> Result<Array1<A>> {
         let mut b = replicate(b);
-        self.solvec_mut(&mut b)?;
+        self.solvec_inplace(&mut b)?;
         Ok(b)
     }
     /// Solves a system of linear equations `A * x = b` with Hermitian (or real
     /// symmetric) positive definite matrix `A`, where `A` is `self`, `b` is
     /// the argument, and `x` is the successful result.
     fn solvec_into<S: DataMut<Elem = A>>(&self, mut b: ArrayBase<S, Ix1>) -> Result<ArrayBase<S, Ix1>> {
-        self.solvec_mut(&mut b)?;
+        self.solvec_inplace(&mut b)?;
         Ok(b)
     }
     /// Solves a system of linear equations `A * x = b` with Hermitian (or real
     /// symmetric) positive definite matrix `A`, where `A` is `self`, `b` is
     /// the argument, and `x` is the successful result. The value of `x` is
     /// also assigned to the argument.
-    fn solvec_mut<'a, S: DataMut<Elem = A>>(&self, &'a mut ArrayBase<S, Ix1>) -> Result<&'a mut ArrayBase<S, Ix1>>;
+    fn solvec_inplace<'a, S: DataMut<Elem = A>>(&self, &'a mut ArrayBase<S, Ix1>) -> Result<&'a mut ArrayBase<S, Ix1>>;
 }
 
 impl<A, S> CholeskySolve<A> for ArrayBase<S, Ix2>
@@ -336,11 +336,11 @@ where
     A: Scalar,
     S: Data<Elem = A>,
 {
-    fn solvec_mut<'a, Sb>(&self, b: &'a mut ArrayBase<Sb, Ix1>) -> Result<&'a mut ArrayBase<Sb, Ix1>>
+    fn solvec_inplace<'a, Sb>(&self, b: &'a mut ArrayBase<Sb, Ix1>) -> Result<&'a mut ArrayBase<Sb, Ix1>>
     where
         Sb: DataMut<Elem = A>,
     {
-        self.factorizec(UPLO::Upper)?.solvec_mut(b)
+        self.factorizec(UPLO::Upper)?.solvec_inplace(b)
     }
 }
 

--- a/src/diagonal.rs
+++ b/src/diagonal.rs
@@ -30,13 +30,13 @@ impl<A, S: Data<Elem = A>> AsDiagonal<A> for ArrayBase<S, Ix1> {
     }
 }
 
-impl<A, S, Sr> OperatorMut<Sr, Ix1> for Diagonal<S>
+impl<A, S, Sr> OperatorInplace<Sr, Ix1> for Diagonal<S>
 where
     A: LinalgScalar,
     S: Data<Elem = A>,
     Sr: DataMut<Elem = A>,
 {
-    fn op_mut<'a>(&self, mut a: &'a mut ArrayBase<Sr, Ix1>) -> &'a mut ArrayBase<Sr, Ix1> {
+    fn op_inplace<'a>(&self, mut a: &'a mut ArrayBase<Sr, Ix1>) -> &'a mut ArrayBase<Sr, Ix1> {
         for (val, d) in a.iter_mut().zip(self.diag.iter()) {
             *val = *val * *d;
         }
@@ -52,7 +52,7 @@ where
 {
     fn op(&self, a: &ArrayBase<Sr, Ix1>) -> Array1<A> {
         let mut a = replicate(a);
-        self.op_mut(&mut a);
+        self.op_inplace(&mut a);
         a
     }
 }
@@ -69,13 +69,13 @@ where
     }
 }
 
-impl<A, S, Sr> OperatorMut<Sr, Ix2> for Diagonal<S>
+impl<A, S, Sr> OperatorInplace<Sr, Ix2> for Diagonal<S>
 where
     A: LinalgScalar,
     S: Data<Elem = A>,
     Sr: DataMut<Elem = A>,
 {
-    fn op_mut<'a>(&self, mut a: &'a mut ArrayBase<Sr, Ix2>) -> &'a mut ArrayBase<Sr, Ix2> {
+    fn op_inplace<'a>(&self, mut a: &'a mut ArrayBase<Sr, Ix2>) -> &'a mut ArrayBase<Sr, Ix2> {
         let ref d = self.diag;
         for ((i, _), val) in a.indexed_iter_mut() {
             *val = *val * d[i];
@@ -92,7 +92,7 @@ where
 {
     fn op(&self, a: &ArrayBase<Sr, Ix2>) -> Array2<A> {
         let mut a = replicate(a);
-        self.op_mut(&mut a);
+        self.op_inplace(&mut a);
         a
     }
 }

--- a/src/eigh.rs
+++ b/src/eigh.rs
@@ -17,9 +17,9 @@ pub trait Eigh {
 }
 
 /// Eigenvalue decomposition of mutable reference of Hermite matrix
-pub trait EighMut {
+pub trait EighInplace {
     type EigVal;
-    fn eigh_mut(&mut self, UPLO) -> Result<(Self::EigVal, &mut Self)>;
+    fn eigh_inplace(&mut self, UPLO) -> Result<(Self::EigVal, &mut Self)>;
 }
 
 /// Eigenvalue decomposition of Hermite matrix
@@ -36,7 +36,7 @@ where
     type EigVal = Array1<A::Real>;
 
     fn eigh_into(mut self, uplo: UPLO) -> Result<(Self::EigVal, Self)> {
-        let (val, _) = self.eigh_mut(uplo)?;
+        let (val, _) = self.eigh_inplace(uplo)?;
         Ok((val, self))
     }
 }
@@ -55,14 +55,14 @@ where
     }
 }
 
-impl<A, S> EighMut for ArrayBase<S, Ix2>
+impl<A, S> EighInplace for ArrayBase<S, Ix2>
 where
     A: Scalar,
     S: DataMut<Elem = A>,
 {
     type EigVal = Array1<A::Real>;
 
-    fn eigh_mut(&mut self, uplo: UPLO) -> Result<(Self::EigVal, &mut Self)> {
+    fn eigh_inplace(&mut self, uplo: UPLO) -> Result<(Self::EigVal, &mut Self)> {
         let s = unsafe { A::eigh(true, self.square_layout()?, uplo, self.as_allocated_mut()?)? };
         Ok((ArrayBase::from_vec(s), self))
     }
@@ -81,9 +81,9 @@ pub trait EigValshInto {
 }
 
 /// Calculate eigenvalues without eigenvectors
-pub trait EigValshMut {
+pub trait EigValshInplace {
     type EigVal;
-    fn eigvalsh_mut(&mut self, UPLO) -> Result<Self::EigVal>;
+    fn eigvalsh_inplace(&mut self, UPLO) -> Result<Self::EigVal>;
 }
 
 impl<A, S> EigValshInto for ArrayBase<S, Ix2>
@@ -94,7 +94,7 @@ where
     type EigVal = Array1<A::Real>;
 
     fn eigvalsh_into(mut self, uplo: UPLO) -> Result<Self::EigVal> {
-        self.eigvalsh_mut(uplo)
+        self.eigvalsh_inplace(uplo)
     }
 }
 
@@ -111,14 +111,14 @@ where
     }
 }
 
-impl<A, S> EigValshMut for ArrayBase<S, Ix2>
+impl<A, S> EigValshInplace for ArrayBase<S, Ix2>
 where
     A: Scalar,
     S: DataMut<Elem = A>,
 {
     type EigVal = Array1<A::Real>;
 
-    fn eigvalsh_mut(&mut self, uplo: UPLO) -> Result<Self::EigVal> {
+    fn eigvalsh_inplace(&mut self, uplo: UPLO) -> Result<Self::EigVal> {
         let s = unsafe { A::eigh(true, self.square_layout()?, uplo, self.as_allocated_mut()?)? };
         Ok(ArrayBase::from_vec(s))
     }

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -20,12 +20,12 @@ where
     fn op_into(&self, ArrayBase<S, D>) -> ArrayBase<S, D>;
 }
 
-pub trait OperatorMut<S, D>
+pub trait OperatorInplace<S, D>
 where
     S: DataMut,
     D: Dimension,
 {
-    fn op_mut<'a>(&self, &'a mut ArrayBase<S, D>) -> &'a mut ArrayBase<S, D>;
+    fn op_inplace<'a>(&self, &'a mut ArrayBase<S, D>) -> &'a mut ArrayBase<S, D>;
 }
 
 impl<T, A, S, D> Operator<A, S, D> for T
@@ -53,7 +53,7 @@ where
     A: Scalar,
     S: DataMut<Elem = A>,
     D: Dimension + RemoveAxis,
-    for<'a> T: OperatorMut<ViewRepr<&'a mut A>, D::Smaller>,
+    for<'a> T: OperatorInplace<ViewRepr<&'a mut A>, D::Smaller>,
 {
     fn op_multi(&self, a: &ArrayBase<S, D>) -> Array<A, D> {
         let a = a.to_owned();
@@ -73,32 +73,32 @@ impl<T, A, S, D> OperatorMultiInto<S, D> for T
 where
     S: DataMut<Elem = A>,
     D: Dimension + RemoveAxis,
-    for<'a> T: OperatorMut<ViewRepr<&'a mut A>, D::Smaller>,
+    for<'a> T: OperatorInplace<ViewRepr<&'a mut A>, D::Smaller>,
 {
     fn op_multi_into(&self, mut a: ArrayBase<S, D>) -> ArrayBase<S, D> {
-        self.op_multi_mut(&mut a);
+        self.op_multi_inplace(&mut a);
         a
     }
 }
 
-pub trait OperatorMultiMut<S, D>
+pub trait OperatorMultiInplace<S, D>
 where
     S: DataMut,
     D: Dimension,
 {
-    fn op_multi_mut<'a>(&self, &'a mut ArrayBase<S, D>) -> &'a mut ArrayBase<S, D>;
+    fn op_multi_inplace<'a>(&self, &'a mut ArrayBase<S, D>) -> &'a mut ArrayBase<S, D>;
 }
 
-impl<T, A, S, D> OperatorMultiMut<S, D> for T
+impl<T, A, S, D> OperatorMultiInplace<S, D> for T
 where
     S: DataMut<Elem = A>,
     D: Dimension + RemoveAxis,
-    for<'a> T: OperatorMut<ViewRepr<&'a mut A>, D::Smaller>,
+    for<'a> T: OperatorInplace<ViewRepr<&'a mut A>, D::Smaller>,
 {
-    fn op_multi_mut<'a>(&self, mut a: &'a mut ArrayBase<S, D>) -> &'a mut ArrayBase<S, D> {
+    fn op_multi_inplace<'a>(&self, mut a: &'a mut ArrayBase<S, D>) -> &'a mut ArrayBase<S, D> {
         let n = a.ndim();
         for mut col in a.axis_iter_mut(Axis(n - 1)) {
-            self.op_mut(&mut col);
+            self.op_inplace(&mut col);
         }
         a
     }

--- a/src/qr.rs
+++ b/src/qr.rs
@@ -47,19 +47,19 @@ pub trait QRSquareInto: Sized {
 }
 
 /// QR decomposition for mutable reference of square matrix
-pub trait QRSquareMut: Sized {
+pub trait QRSquareInplace: Sized {
     type R;
-    fn qr_square_mut<'a>(&'a mut self) -> Result<(&'a mut Self, Self::R)>;
+    fn qr_square_inplace<'a>(&'a mut self) -> Result<(&'a mut Self, Self::R)>;
 }
 
-impl<A, S> QRSquareMut for ArrayBase<S, Ix2>
+impl<A, S> QRSquareInplace for ArrayBase<S, Ix2>
 where
     A: Scalar,
     S: DataMut<Elem = A>,
 {
     type R = Array2<A>;
 
-    fn qr_square_mut<'a>(&'a mut self) -> Result<(&'a mut Self, Self::R)> {
+    fn qr_square_inplace<'a>(&'a mut self) -> Result<(&'a mut Self, Self::R)> {
         let l = self.square_layout()?;
         let r = unsafe { A::qr(l, self.as_allocated_mut()?)? };
         let r: Array2<_> = into_matrix(l, r)?;
@@ -75,7 +75,7 @@ where
     type R = Array2<A>;
 
     fn qr_square_into(mut self) -> Result<(Self, Self::R)> {
-        let (_, r) = self.qr_square_mut()?;
+        let (_, r) = self.qr_square_inplace()?;
         Ok((self, r))
     }
 }

--- a/src/solve.rs
+++ b/src/solve.rs
@@ -66,7 +66,7 @@ pub use lapack_traits::{Pivot, Transpose};
 ///
 /// * `*` methods take a reference to `b` and return `x` as a new array.
 /// * `*_into` methods take ownership of `b`, store the result in it, and return it.
-/// * `*_mut` methods take a mutable reference to `b` and store the result in that array.
+/// * `*_inplace` methods take a mutable reference to `b` and store the result in that array.
 ///
 /// If you plan to solve many equations with the same `A` matrix but different
 /// `b` vectors, it's faster to factor the `A` matrix once using the
@@ -76,52 +76,54 @@ pub trait Solve<A: Scalar> {
     /// is the argument, and `x` is the successful result.
     fn solve<S: Data<Elem = A>>(&self, b: &ArrayBase<S, Ix1>) -> Result<Array1<A>> {
         let mut b = replicate(b);
-        self.solve_mut(&mut b)?;
+        self.solve_inplace(&mut b)?;
         Ok(b)
     }
     /// Solves a system of linear equations `A * x = b` where `A` is `self`, `b`
     /// is the argument, and `x` is the successful result.
     fn solve_into<S: DataMut<Elem = A>>(&self, mut b: ArrayBase<S, Ix1>) -> Result<ArrayBase<S, Ix1>> {
-        self.solve_mut(&mut b)?;
+        self.solve_inplace(&mut b)?;
         Ok(b)
     }
     /// Solves a system of linear equations `A * x = b` where `A` is `self`, `b`
     /// is the argument, and `x` is the successful result.
-    fn solve_mut<'a, S: DataMut<Elem = A>>(&self, &'a mut ArrayBase<S, Ix1>) -> Result<&'a mut ArrayBase<S, Ix1>>;
+    fn solve_inplace<'a, S: DataMut<Elem = A>>(&self, &'a mut ArrayBase<S, Ix1>) -> Result<&'a mut ArrayBase<S, Ix1>>;
 
     /// Solves a system of linear equations `A^T * x = b` where `A` is `self`, `b`
     /// is the argument, and `x` is the successful result.
     fn solve_t<S: Data<Elem = A>>(&self, b: &ArrayBase<S, Ix1>) -> Result<Array1<A>> {
         let mut b = replicate(b);
-        self.solve_t_mut(&mut b)?;
+        self.solve_t_inplace(&mut b)?;
         Ok(b)
     }
     /// Solves a system of linear equations `A^T * x = b` where `A` is `self`, `b`
     /// is the argument, and `x` is the successful result.
     fn solve_t_into<S: DataMut<Elem = A>>(&self, mut b: ArrayBase<S, Ix1>) -> Result<ArrayBase<S, Ix1>> {
-        self.solve_t_mut(&mut b)?;
+        self.solve_t_inplace(&mut b)?;
         Ok(b)
     }
     /// Solves a system of linear equations `A^T * x = b` where `A` is `self`, `b`
     /// is the argument, and `x` is the successful result.
-    fn solve_t_mut<'a, S: DataMut<Elem = A>>(&self, &'a mut ArrayBase<S, Ix1>) -> Result<&'a mut ArrayBase<S, Ix1>>;
+    fn solve_t_inplace<'a, S: DataMut<Elem = A>>(&self, &'a mut ArrayBase<S, Ix1>)
+        -> Result<&'a mut ArrayBase<S, Ix1>>;
 
     /// Solves a system of linear equations `A^H * x = b` where `A` is `self`, `b`
     /// is the argument, and `x` is the successful result.
     fn solve_h<S: Data<Elem = A>>(&self, b: &ArrayBase<S, Ix1>) -> Result<Array1<A>> {
         let mut b = replicate(b);
-        self.solve_h_mut(&mut b)?;
+        self.solve_h_inplace(&mut b)?;
         Ok(b)
     }
     /// Solves a system of linear equations `A^H * x = b` where `A` is `self`, `b`
     /// is the argument, and `x` is the successful result.
     fn solve_h_into<S: DataMut<Elem = A>>(&self, mut b: ArrayBase<S, Ix1>) -> Result<ArrayBase<S, Ix1>> {
-        self.solve_h_mut(&mut b)?;
+        self.solve_h_inplace(&mut b)?;
         Ok(b)
     }
     /// Solves a system of linear equations `A^H * x = b` where `A` is `self`, `b`
     /// is the argument, and `x` is the successful result.
-    fn solve_h_mut<'a, S: DataMut<Elem = A>>(&self, &'a mut ArrayBase<S, Ix1>) -> Result<&'a mut ArrayBase<S, Ix1>>;
+    fn solve_h_inplace<'a, S: DataMut<Elem = A>>(&self, &'a mut ArrayBase<S, Ix1>)
+        -> Result<&'a mut ArrayBase<S, Ix1>>;
 }
 
 /// Represents the LU factorization of a matrix `A` as `A = P*L*U`.
@@ -138,7 +140,7 @@ where
     A: Scalar,
     S: Data<Elem = A>,
 {
-    fn solve_mut<'a, Sb>(&self, mut rhs: &'a mut ArrayBase<Sb, Ix1>) -> Result<&'a mut ArrayBase<Sb, Ix1>>
+    fn solve_inplace<'a, Sb>(&self, mut rhs: &'a mut ArrayBase<Sb, Ix1>) -> Result<&'a mut ArrayBase<Sb, Ix1>>
     where
         Sb: DataMut<Elem = A>,
     {
@@ -153,7 +155,7 @@ where
         };
         Ok(rhs)
     }
-    fn solve_t_mut<'a, Sb>(&self, mut rhs: &'a mut ArrayBase<Sb, Ix1>) -> Result<&'a mut ArrayBase<Sb, Ix1>>
+    fn solve_t_inplace<'a, Sb>(&self, mut rhs: &'a mut ArrayBase<Sb, Ix1>) -> Result<&'a mut ArrayBase<Sb, Ix1>>
     where
         Sb: DataMut<Elem = A>,
     {
@@ -168,7 +170,7 @@ where
         };
         Ok(rhs)
     }
-    fn solve_h_mut<'a, Sb>(&self, mut rhs: &'a mut ArrayBase<Sb, Ix1>) -> Result<&'a mut ArrayBase<Sb, Ix1>>
+    fn solve_h_inplace<'a, Sb>(&self, mut rhs: &'a mut ArrayBase<Sb, Ix1>) -> Result<&'a mut ArrayBase<Sb, Ix1>>
     where
         Sb: DataMut<Elem = A>,
     {
@@ -190,26 +192,26 @@ where
     A: Scalar,
     S: Data<Elem = A>,
 {
-    fn solve_mut<'a, Sb>(&self, mut rhs: &'a mut ArrayBase<Sb, Ix1>) -> Result<&'a mut ArrayBase<Sb, Ix1>>
+    fn solve_inplace<'a, Sb>(&self, mut rhs: &'a mut ArrayBase<Sb, Ix1>) -> Result<&'a mut ArrayBase<Sb, Ix1>>
     where
         Sb: DataMut<Elem = A>,
     {
         let f = self.factorize()?;
-        f.solve_mut(rhs)
+        f.solve_inplace(rhs)
     }
-    fn solve_t_mut<'a, Sb>(&self, mut rhs: &'a mut ArrayBase<Sb, Ix1>) -> Result<&'a mut ArrayBase<Sb, Ix1>>
+    fn solve_t_inplace<'a, Sb>(&self, mut rhs: &'a mut ArrayBase<Sb, Ix1>) -> Result<&'a mut ArrayBase<Sb, Ix1>>
     where
         Sb: DataMut<Elem = A>,
     {
         let f = self.factorize()?;
-        f.solve_t_mut(rhs)
+        f.solve_t_inplace(rhs)
     }
-    fn solve_h_mut<'a, Sb>(&self, mut rhs: &'a mut ArrayBase<Sb, Ix1>) -> Result<&'a mut ArrayBase<Sb, Ix1>>
+    fn solve_h_inplace<'a, Sb>(&self, mut rhs: &'a mut ArrayBase<Sb, Ix1>) -> Result<&'a mut ArrayBase<Sb, Ix1>>
     where
         Sb: DataMut<Elem = A>,
     {
         let f = self.factorize()?;
-        f.solve_h_mut(rhs)
+        f.solve_h_inplace(rhs)
     }
 }
 

--- a/src/solveh.rs
+++ b/src/solveh.rs
@@ -70,21 +70,21 @@ pub trait SolveH<A: Scalar> {
     /// `x` is the successful result.
     fn solveh<S: Data<Elem = A>>(&self, b: &ArrayBase<S, Ix1>) -> Result<Array1<A>> {
         let mut b = replicate(b);
-        self.solveh_mut(&mut b)?;
+        self.solveh_inplace(&mut b)?;
         Ok(b)
     }
     /// Solves a system of linear equations `A * x = b` with Hermitian (or real
     /// symmetric) matrix `A`, where `A` is `self`, `b` is the argument, and
     /// `x` is the successful result.
     fn solveh_into<S: DataMut<Elem = A>>(&self, mut b: ArrayBase<S, Ix1>) -> Result<ArrayBase<S, Ix1>> {
-        self.solveh_mut(&mut b)?;
+        self.solveh_inplace(&mut b)?;
         Ok(b)
     }
     /// Solves a system of linear equations `A * x = b` with Hermitian (or real
     /// symmetric) matrix `A`, where `A` is `self`, `b` is the argument, and
     /// `x` is the successful result. The value of `x` is also assigned to the
     /// argument.
-    fn solveh_mut<'a, S: DataMut<Elem = A>>(&self, &'a mut ArrayBase<S, Ix1>) -> Result<&'a mut ArrayBase<S, Ix1>>;
+    fn solveh_inplace<'a, S: DataMut<Elem = A>>(&self, &'a mut ArrayBase<S, Ix1>) -> Result<&'a mut ArrayBase<S, Ix1>>;
 }
 
 /// Represents the Bunch–Kaufman factorization of a Hermitian (or real
@@ -99,7 +99,7 @@ where
     A: Scalar,
     S: Data<Elem = A>,
 {
-    fn solveh_mut<'a, Sb>(&self, rhs: &'a mut ArrayBase<Sb, Ix1>) -> Result<&'a mut ArrayBase<Sb, Ix1>>
+    fn solveh_inplace<'a, Sb>(&self, rhs: &'a mut ArrayBase<Sb, Ix1>) -> Result<&'a mut ArrayBase<Sb, Ix1>>
     where
         Sb: DataMut<Elem = A>,
     {
@@ -121,12 +121,12 @@ where
     A: Scalar,
     S: Data<Elem = A>,
 {
-    fn solveh_mut<'a, Sb>(&self, mut rhs: &'a mut ArrayBase<Sb, Ix1>) -> Result<&'a mut ArrayBase<Sb, Ix1>>
+    fn solveh_inplace<'a, Sb>(&self, mut rhs: &'a mut ArrayBase<Sb, Ix1>) -> Result<&'a mut ArrayBase<Sb, Ix1>>
     where
         Sb: DataMut<Elem = A>,
     {
         let f = self.factorizeh()?;
-        f.solveh_mut(rhs)
+        f.solveh_inplace(rhs)
     }
 }
 

--- a/src/svd.rs
+++ b/src/svd.rs
@@ -26,11 +26,11 @@ pub trait SVDInto {
 }
 
 /// singular-value decomposition for mutable reference of matrix
-pub trait SVDMut {
+pub trait SVDInplace {
     type U;
     type VT;
     type Sigma;
-    fn svd_mut(&mut self, calc_u: bool, calc_vt: bool) -> Result<(Option<Self::U>, Self::Sigma, Option<Self::VT>)>;
+    fn svd_inplace(&mut self, calc_u: bool, calc_vt: bool) -> Result<(Option<Self::U>, Self::Sigma, Option<Self::VT>)>;
 }
 
 impl<A, S> SVDInto for ArrayBase<S, Ix2>
@@ -43,7 +43,7 @@ where
     type Sigma = Array1<A::Real>;
 
     fn svd_into(mut self, calc_u: bool, calc_vt: bool) -> Result<(Option<Self::U>, Self::Sigma, Option<Self::VT>)> {
-        self.svd_mut(calc_u, calc_vt)
+        self.svd_inplace(calc_u, calc_vt)
     }
 }
 
@@ -62,7 +62,7 @@ where
     }
 }
 
-impl<A, S> SVDMut for ArrayBase<S, Ix2>
+impl<A, S> SVDInplace for ArrayBase<S, Ix2>
 where
     A: Scalar,
     S: DataMut<Elem = A>,
@@ -71,7 +71,7 @@ where
     type VT = Array2<A>;
     type Sigma = Array1<A::Real>;
 
-    fn svd_mut(&mut self, calc_u: bool, calc_vt: bool) -> Result<(Option<Self::U>, Self::Sigma, Option<Self::VT>)> {
+    fn svd_inplace(&mut self, calc_u: bool, calc_vt: bool) -> Result<(Option<Self::U>, Self::Sigma, Option<Self::VT>)> {
         let l = self.layout()?;
         let svd_res = unsafe { A::svd(l, calc_u, calc_vt, self.as_allocated_mut()?)? };
         let (n, m) = l.size();

--- a/src/triangular.rs
+++ b/src/triangular.rs
@@ -32,12 +32,12 @@ where
 }
 
 /// solve a triangular system with upper triangular matrix
-pub trait SolveTriangularMut<S, D>
+pub trait SolveTriangularInplace<S, D>
 where
     S: DataMut,
     D: Dimension,
 {
-    fn solve_triangular_mut<'a>(&self, UPLO, Diag, &'a mut ArrayBase<S, D>) -> Result<&'a mut ArrayBase<S, D>>;
+    fn solve_triangular_inplace<'a>(&self, UPLO, Diag, &'a mut ArrayBase<S, D>) -> Result<&'a mut ArrayBase<S, D>>;
 }
 
 impl<A, Si, So> SolveTriangularInto<So, Ix2> for ArrayBase<Si, Ix2>
@@ -47,18 +47,18 @@ where
     So: DataMut<Elem = A> + DataOwned,
 {
     fn solve_triangular_into(&self, uplo: UPLO, diag: Diag, mut b: ArrayBase<So, Ix2>) -> Result<ArrayBase<So, Ix2>> {
-        self.solve_triangular_mut(uplo, diag, &mut b)?;
+        self.solve_triangular_inplace(uplo, diag, &mut b)?;
         Ok(b)
     }
 }
 
-impl<A, Si, So> SolveTriangularMut<So, Ix2> for ArrayBase<Si, Ix2>
+impl<A, Si, So> SolveTriangularInplace<So, Ix2> for ArrayBase<Si, Ix2>
 where
     A: Scalar,
     Si: Data<Elem = A>,
     So: DataMut<Elem = A> + DataOwned,
 {
-    fn solve_triangular_mut<'a>(
+    fn solve_triangular_inplace<'a>(
         &self,
         uplo: UPLO,
         diag: Diag,

--- a/tests/cholesky.rs
+++ b/tests/cholesky.rs
@@ -29,14 +29,14 @@ fn cholesky() {
 
             let mut a: Array2<$elem> = replicate(&a_orig);
             {
-                let upper = a.cholesky_mut(UPLO::Upper).unwrap();
+                let upper = a.cholesky_inplace(UPLO::Upper).unwrap();
                 assert_close_l2!(&upper.t().mapv(|elem| elem.conj()).dot(&upper.view()), &a_orig, $rtol);
             }
             assert_close_l2!(&a.t().mapv(|elem| elem.conj()).dot(&upper.view()), &a_orig, $rtol);
 
             let mut a: Array2<$elem> = replicate(&a_orig);
             {
-                let lower = a.cholesky_mut(UPLO::Lower).unwrap();
+                let lower = a.cholesky_inplace(UPLO::Lower).unwrap();
                 assert_close_l2!(&lower.dot(&lower.t().mapv(|elem| elem.conj())), &a_orig, $rtol);
             }
             assert_close_l2!(&a.dot(&lower.t().mapv(|elem| elem.conj())), &a_orig, $rtol);
@@ -127,13 +127,13 @@ fn cholesky_solve() {
             println!("x = \n{:?}", x);
             assert_close_l2!(&a.solvec(&b).unwrap(), &x, $rtol);
             assert_close_l2!(&a.solvec_into(b.clone()).unwrap(), &x, $rtol);
-            assert_close_l2!(&a.solvec_mut(&mut b.clone()).unwrap(), &x, $rtol);
+            assert_close_l2!(&a.solvec_inplace(&mut b.clone()).unwrap(), &x, $rtol);
             assert_close_l2!(&a.factorizec(UPLO::Upper).unwrap().solvec(&b).unwrap(), &x, $rtol);
             assert_close_l2!(&a.factorizec(UPLO::Lower).unwrap().solvec(&b).unwrap(), &x, $rtol);
             assert_close_l2!(&a.factorizec(UPLO::Upper).unwrap().solvec_into(b.clone()).unwrap(), &x, $rtol);
             assert_close_l2!(&a.factorizec(UPLO::Lower).unwrap().solvec_into(b.clone()).unwrap(), &x, $rtol);
-            assert_close_l2!(&a.factorizec(UPLO::Upper).unwrap().solvec_mut(&mut b.clone()).unwrap(), &x, $rtol);
-            assert_close_l2!(&a.factorizec(UPLO::Lower).unwrap().solvec_mut(&mut b.clone()).unwrap(), &x, $rtol);
+            assert_close_l2!(&a.factorizec(UPLO::Upper).unwrap().solvec_inplace(&mut b.clone()).unwrap(), &x, $rtol);
+            assert_close_l2!(&a.factorizec(UPLO::Lower).unwrap().solvec_inplace(&mut b.clone()).unwrap(), &x, $rtol);
         }
     }
     cholesky_solve!(f64, 1e-9);


### PR DESCRIPTION
This implements the renaming portion of #83.

In `ndarray`, `*_mut` methods return mutable views or references to the contents of the array, while `*_inplace` methods actually modify data in-place. This PR renames the `ndarray-linalg` methods to match that convention.

For the trait names, I used `*Inplace` to match the snake-case method names, although I can change them to `*InPlace` if you prefer.