### PR TITLE
Add determinant for Hermitian matrices in `solveh` module

### DIFF
--- a/src/lapack_traits/solveh.rs
+++ b/src/lapack_traits/solveh.rs
@@ -26,8 +26,13 @@ impl Solveh_ for $scalar {
     unsafe fn bk(l: MatrixLayout, uplo: UPLO, a: &mut [Self]) -> Result<Pivot> {
         let (n, _) = l.size();
         let mut ipiv = vec![0; n as usize];
-        let info = $trf(l.lapacke_layout(), uplo as u8, n, a, l.lda(), &mut ipiv);
-        into_result(info, ipiv)
+        if n == 0 {
+            // Work around bug in LAPACKE functions.
+            Ok(ipiv)
+        } else {
+            let info = $trf(l.lapacke_layout(), uplo as u8, n, a, l.lda(), &mut ipiv);
+            into_result(info, ipiv)
+        }
     }
 
     unsafe fn invh(l: MatrixLayout, uplo: UPLO, a: &mut [Self], ipiv: &Pivot) -> Result<()> {

--- a/src/solveh.rs
+++ b/src/solveh.rs
@@ -153,7 +153,7 @@ where
     S: DataMut<Elem = A>,
 {
     fn factorizeh_into(mut self) -> Result<BKFactorized<S>> {
-        let ipiv = unsafe { A::bk(self.layout()?, UPLO::Upper, self.as_allocated_mut()?)? };
+        let ipiv = unsafe { A::bk(self.square_layout()?, UPLO::Upper, self.as_allocated_mut()?)? };
         Ok(BKFactorized {
             a: self,
             ipiv: ipiv,
@@ -168,7 +168,7 @@ where
 {
     fn factorizeh(&self) -> Result<BKFactorized<OwnedRepr<A>>> {
         let mut a: Array2<A> = replicate(self);
-        let ipiv = unsafe { A::bk(a.layout()?, UPLO::Upper, a.as_allocated_mut()?)? };
+        let ipiv = unsafe { A::bk(a.square_layout()?, UPLO::Upper, a.as_allocated_mut()?)? };
         Ok(BKFactorized { a: a, ipiv: ipiv })
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -87,6 +87,10 @@ pub fn into_scalar<T: Scalar>(f: f64) -> T {
 pub trait AssociatedReal: Sized {
     type Real: RealScalar;
     fn inject(Self::Real) -> Self;
+    /// Returns the real part of `self`.
+    fn real(self) -> Self::Real;
+    /// Returns the imaginary part of `self`.
+    fn imag(self) -> Self::Real;
     fn add_real(self, Self::Real) -> Self;
     fn sub_real(self, Self::Real) -> Self;
     fn mul_real(self, Self::Real) -> Self;
@@ -141,6 +145,8 @@ macro_rules! impl_traits {
 impl AssociatedReal for $real {
     type Real = $real;
     fn inject(r: Self::Real) -> Self { r }
+    fn real(self) -> Self::Real { self }
+    fn imag(self) -> Self::Real { 0. }
     fn add_real(self, r: Self::Real) -> Self { self + r }
     fn sub_real(self, r: Self::Real) -> Self { self - r }
     fn mul_real(self, r: Self::Real) -> Self { self * r }
@@ -150,6 +156,8 @@ impl AssociatedReal for $real {
 impl AssociatedReal for $complex {
     type Real = $real;
     fn inject(r: Self::Real) -> Self { Self::new(r, 0.0) }
+    fn real(self) -> Self::Real { self.re }
+    fn imag(self) -> Self::Real { self.im }
     fn add_real(self, r: Self::Real) -> Self { self + r }
     fn sub_real(self, r: Self::Real) -> Self { self - r }
     fn mul_real(self, r: Self::Real) -> Self { self * r }

--- a/tests/solveh.rs
+++ b/tests/solveh.rs
@@ -1,0 +1,99 @@
+extern crate ndarray;
+#[macro_use]
+extern crate ndarray_linalg;
+extern crate num_traits;
+
+use ndarray::*;
+use ndarray_linalg::*;
+use num_traits::{One, Zero};
+
+#[test]
+fn deth_empty() {
+    macro_rules! deth_empty {
+        ($elem:ty) => {
+            let a: Array2<$elem> = Array2::zeros((0, 0));
+            assert_eq!(a.factorizeh().unwrap().deth(), One::one());
+            assert_eq!(a.factorizeh().unwrap().deth_into(), One::one());
+            assert_eq!(a.deth().unwrap(), One::one());
+            assert_eq!(a.deth_into().unwrap(), One::one());
+        }
+    }
+    deth_empty!(f64);
+    deth_empty!(f32);
+    deth_empty!(c64);
+    deth_empty!(c32);
+}
+
+#[test]
+fn deth_zero() {
+    macro_rules! deth_zero {
+        ($elem:ty) => {
+            let a: Array2<$elem> = Array2::zeros((1, 1));
+            assert_eq!(a.deth().unwrap(), Zero::zero());
+            assert_eq!(a.deth_into().unwrap(), Zero::zero());
+        }
+    }
+    deth_zero!(f64);
+    deth_zero!(f32);
+    deth_zero!(c64);
+    deth_zero!(c32);
+}
+
+#[test]
+fn deth_zero_nonsquare() {
+    macro_rules! deth_zero_nonsquare {
+        ($elem:ty, $shape:expr) => {
+            let a: Array2<$elem> = Array2::zeros($shape);
+            assert!(a.deth().is_err());
+            assert!(a.deth_into().is_err());
+        }
+    }
+    for &shape in &[(1, 2).into_shape(), (1, 2).f()] {
+        deth_zero_nonsquare!(f64, shape);
+        deth_zero_nonsquare!(f32, shape);
+        deth_zero_nonsquare!(c64, shape);
+        deth_zero_nonsquare!(c32, shape);
+    }
+}
+
+#[test]
+fn deth() {
+    macro_rules! deth {
+        ($elem:ty, $rows:expr, $atol:expr) => {
+            let a: Array2<$elem> = random_hermite($rows);
+            println!("a = \n{:?}", a);
+            let det = a.eigvalsh(UPLO::Upper).unwrap().iter().product();
+            assert_aclose!(a.factorizeh().unwrap().deth(), det, $atol);
+            assert_aclose!(a.factorizeh().unwrap().deth_into(), det, $atol);
+            assert_aclose!(a.deth().unwrap(), det, $atol);
+            assert_aclose!(a.deth_into().unwrap(), det, $atol);
+        }
+    }
+    for rows in 1..6 {
+        deth!(f64, rows, 1e-9);
+        deth!(f32, rows, 1e-3);
+        deth!(c64, rows, 1e-9);
+        deth!(c32, rows, 1e-3);
+    }
+}
+
+#[test]
+fn deth_nonsquare() {
+    macro_rules! deth_nonsquare {
+        ($elem:ty, $shape:expr) => {
+            let a: Array2<$elem> = Array2::zeros($shape);
+            assert!(a.factorizeh().is_err());
+            assert!(a.factorizeh().is_err());
+            assert!(a.deth().is_err());
+            assert!(a.deth_into().is_err());
+        }
+    }
+    for &dims in &[(1, 0), (1, 2), (2, 1), (2, 3)] {
+        for &shape in &[dims.clone().into_shape(), dims.clone().f()] {
+            deth_nonsquare!(f64, shape);
+            deth_nonsquare!(f32, shape);
+            deth_nonsquare!(c64, shape);
+            deth_nonsquare!(c32, shape);
+        }
+    }
+}


### PR DESCRIPTION
This adds `deth()` and `deth_into()` methods for Hermitian matrices in the `solveh` module. It also fixes `bk()` for zero-size matrices (workaround for a bug in the LAPACKE routines; see the commit message for details). Note that this PR makes the following breaking changes:

* Require the input array to `factorizeh*()` to be square. (See the commit message for reasoning.)
* Add `AssociatedReal::real()` and `AssociatedReal::imag()` for use in `bk_det()`. (I didn't see any other obvious way to take the real part of a complex number using the methods that already existed.)

Edit: Would you prefer the trait names `BKDeterminant` and `BKDeterminantInto`?