### PR TITLE
Use lapacke library, drop linking to LAPACKE implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ Cargo.lock
 
 # cargo fmt
 *.bk
+
+# IntelliJ Rust
+.idea
+*.iml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ndarray-linalg"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Toshiki Teramura <toshiki.teramura@gmail.com>"]
 
 description   = "Linear algebra package for rust-ndarray using LAPACK"
@@ -11,40 +11,20 @@ license       = "MIT"
 readme        = "README.md"
 categories    = ["algorithms", "science"]
 
-[features]
-default  = ["openblas-static"]
-openblas-shared = ["lapack/openblas"]
-openblas-static = ["lapack/openblas", "openblas-src/static"]
-openblas-system = ["lapack/openblas", "openblas-src/system"]
-netlib-shared   = ["lapack/netlib"]
-netlib-static   = ["lapack/netlib", "netlib-src/static"]
-netlib-system   = ["lapack/netlib", "netlib-src/system"]
-intel-mkl       = ["intel-mkl-src"]
-
 [dependencies]
 rand = "0.3"
 derive-new = "0.5"
 procedurals = "0.2"
 num-traits  = "0.1"
-num-complex = "0.1"
-lapack = { version = "0.13", default-features = false }
-lapack-sys = { version = "0.11", default-features = false }
+num-complex = { version = "0.1", default-features = false }
+lapacke = "0.1.4"
+lapack-src = { git = "https://github.com/alexbool/lapack-src", rev = "da33354", optional = true }
 
 [dependencies.ndarray]
 version = "0.10"
 default-features = false
 
-[dependencies.openblas-src]
-version = "0.5.3"
-default-features = false
-optional = true
-
-[dependencies.netlib-src]
-version = "0.7.0"
-default-features = false
-optional = true
-
-[dependencies.intel-mkl-src]
-version = "0.2.5"
-default-features = false
-optional = true
+[features]
+openblas = ["lapack-src", "lapack-src/openblas"]
+netlib = ["lapack-src", "lapack-src/netlib"]
+intel-mkl = ["lapack-src", "lapack-src/intel-mkl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ intel-mkl       = ["intel-mkl-src"]
 
 [dependencies]
 rand = "0.3"
-derive-new = "0.4"
+derive-new = "0.5"
 procedurals = "0.2"
 num-traits  = "0.1"
 num-complex = "0.1"

--- a/README.md
+++ b/README.md
@@ -10,23 +10,38 @@ Dependencies
 -------------
 
 - [bluss/rust-ndarray](https://github.com/bluss/rust-ndarray)
-- [stainless-steel/lapack](https://github.com/stainless-steel/lapack)
+- [blas-lapack-rs/lapacke](https://github.com/blas-lapack-rs/lapacke)
 
 and more (See Cargo.toml).
 
-Feature flags
---------------
+Choosing LAPACKE implementation
+--------------------------------
+
+For the sake of linking flexibility, you must provide LAPACKE implementation (as an `extern crate`) yourself.
+Currently three LAPACKE implementations are supported and tested:
 
 - [OpenBLAS](https://github.com/cmr/openblas-src)
-  - `openblas-static`: use OpenBLAS with static link (default)
-  - `openblas-shared`: use OpenBLAS with shared link
-  - `openblas-system`: use system OpenBLAS (experimental)
 - [Netlib](https://github.com/cmr/netlib-src)
-  - `netlib-static`: use Netlib with static link (default)
-  - `netlib-shared`: use Netlib with shared link
-  - `netlib-system`: use system Netlib (experimental)
 - [Intel MKL](https://github.com/termoshtt/rust-intel-mkl) (non-free license, see the linked page)
-  - `intel-mkl`: use Intel MKL shared link (experimental)
+
+You should link a LAPACKE implementation to a final crate (like binary executable or dylib) only, not to a Rust library.
+Example:
+
+`Cargo.toml`:
+```toml
+[depencdencies]
+ndarray = "0.10"
+ndarray-linalg = "0.8"
+openblas-src = "0.5" # or another backend of your choice
+
+```
+
+`main.rs`:
+```rust
+extern crate ndarray;
+extern crate ndarray_linalg;
+extern crate openblas_src; // or another backend of your choice
+```
 
 Examples
 ---------

--- a/examples/eigh.rs
+++ b/examples/eigh.rs
@@ -1,6 +1,8 @@
 
 extern crate ndarray;
 extern crate ndarray_linalg;
+#[cfg(feature = "lapack-src")]
+extern crate lapack_src;
 
 use ndarray::*;
 use ndarray_linalg::*;

--- a/examples/solve.rs
+++ b/examples/solve.rs
@@ -1,6 +1,8 @@
 
 extern crate ndarray;
 extern crate ndarray_linalg;
+#[cfg(feature = "lapack-src")]
+extern crate lapack_src;
 
 use ndarray::*;
 use ndarray_linalg::*;

--- a/examples/solveh.rs
+++ b/examples/solveh.rs
@@ -1,6 +1,8 @@
 
 extern crate ndarray;
 extern crate ndarray_linalg;
+#[cfg(feature = "lapack-src")]
+extern crate lapack_src;
 
 use ndarray::*;
 use ndarray_linalg::*;

--- a/src/cholesky.rs
+++ b/src/cholesky.rs
@@ -9,7 +9,7 @@
 //! Using the Cholesky decomposition of `A` for various operations, where `A`
 //! is a Hermitian (or real symmetric) positive definite matrix:
 //!
-//! ```
+//! ```no_run
 //! #[macro_use]
 //! extern crate ndarray;
 //! extern crate ndarray_linalg;

--- a/src/lapack_traits/cholesky.rs
+++ b/src/lapack_traits/cholesky.rs
@@ -1,6 +1,6 @@
 //! Cholesky decomposition
 
-use lapack::c;
+use lapacke;
 
 use error::*;
 use layout::MatrixLayout;
@@ -46,7 +46,7 @@ impl Cholesky_ for $scalar {
 }
 }} // end macro_rules
 
-impl_cholesky!(f64, c::dpotrf, c::dpotri, c::dpotrs);
-impl_cholesky!(f32, c::spotrf, c::spotri, c::spotrs);
-impl_cholesky!(c64, c::zpotrf, c::zpotri, c::zpotrs);
-impl_cholesky!(c32, c::cpotrf, c::cpotri, c::cpotrs);
+impl_cholesky!(f64, lapacke::dpotrf, lapacke::dpotri, lapacke::dpotrs);
+impl_cholesky!(f32, lapacke::spotrf, lapacke::spotri, lapacke::spotrs);
+impl_cholesky!(c64, lapacke::zpotrf, lapacke::zpotri, lapacke::zpotrs);
+impl_cholesky!(c32, lapacke::cpotrf, lapacke::cpotri, lapacke::cpotrs);

--- a/src/lapack_traits/eigh.rs
+++ b/src/lapack_traits/eigh.rs
@@ -1,6 +1,6 @@
 //! Eigenvalue decomposition for Hermite matrices
 
-use lapack::c;
+use lapacke;
 use num_traits::Zero;
 
 use error::*;
@@ -27,7 +27,7 @@ impl Eigh_ for $scalar {
 }
 }} // impl_eigh!
 
-impl_eigh!(f64, c::dsyev);
-impl_eigh!(f32, c::ssyev);
-impl_eigh!(c64, c::zheev);
-impl_eigh!(c32, c::cheev);
+impl_eigh!(f64, lapacke::dsyev);
+impl_eigh!(f32, lapacke::ssyev);
+impl_eigh!(c64, lapacke::zheev);
+impl_eigh!(c32, lapacke::cheev);

--- a/src/lapack_traits/opnorm.rs
+++ b/src/lapack_traits/opnorm.rs
@@ -1,7 +1,7 @@
 //! Operator norms of matrices
 
-use lapack::c;
-use lapack::c::Layout::ColumnMajor as cm;
+use lapacke;
+use lapacke::Layout::ColumnMajor as cm;
 
 use layout::MatrixLayout;
 use types::*;
@@ -24,7 +24,7 @@ impl OperatorNorm_ for $scalar {
 }
 }} // impl_opnorm!
 
-impl_opnorm!(f64, c::dlange);
-impl_opnorm!(f32, c::slange);
-impl_opnorm!(c64, c::zlange);
-impl_opnorm!(c32, c::clange);
+impl_opnorm!(f64, lapacke::dlange);
+impl_opnorm!(f32, lapacke::slange);
+impl_opnorm!(c64, lapacke::zlange);
+impl_opnorm!(c32, lapacke::clange);

--- a/src/lapack_traits/qr.rs
+++ b/src/lapack_traits/qr.rs
@@ -1,6 +1,6 @@
 //! QR decomposition
 
-use lapack::c;
+use lapacke;
 use num_traits::Zero;
 use std::cmp::min;
 
@@ -44,7 +44,7 @@ impl QR_ for $scalar {
 }
 }} // endmacro
 
-impl_qr!(f64, c::dgeqrf, c::dorgqr);
-impl_qr!(f32, c::sgeqrf, c::sorgqr);
-impl_qr!(c64, c::zgeqrf, c::zungqr);
-impl_qr!(c32, c::cgeqrf, c::cungqr);
+impl_qr!(f64, lapacke::dgeqrf, lapacke::dorgqr);
+impl_qr!(f32, lapacke::sgeqrf, lapacke::sorgqr);
+impl_qr!(c64, lapacke::zgeqrf, lapacke::zungqr);
+impl_qr!(c32, lapacke::cgeqrf, lapacke::cungqr);

--- a/src/lapack_traits/solve.rs
+++ b/src/lapack_traits/solve.rs
@@ -1,6 +1,6 @@
 //! Solve linear problem using LU decomposition
 
-use lapack::c;
+use lapacke;
 
 use error::*;
 use layout::MatrixLayout;
@@ -65,7 +65,7 @@ impl Solve_ for $scalar {
 
 }} // impl_solve!
 
-impl_solve!(f64, c::dgetrf, c::dgetri, c::dgecon, c::dgetrs);
-impl_solve!(f32, c::sgetrf, c::sgetri, c::sgecon, c::sgetrs);
-impl_solve!(c64, c::zgetrf, c::zgetri, c::zgecon, c::zgetrs);
-impl_solve!(c32, c::cgetrf, c::cgetri, c::cgecon, c::cgetrs);
+impl_solve!(f64, lapacke::dgetrf, lapacke::dgetri, lapacke::dgecon, lapacke::dgetrs);
+impl_solve!(f32, lapacke::sgetrf, lapacke::sgetri, lapacke::sgecon, lapacke::sgetrs);
+impl_solve!(c64, lapacke::zgetrf, lapacke::zgetri, lapacke::zgecon, lapacke::zgetrs);
+impl_solve!(c32, lapacke::cgetrf, lapacke::cgetri, lapacke::cgecon, lapacke::cgetrs);

--- a/src/lapack_traits/solveh.rs
+++ b/src/lapack_traits/solveh.rs
@@ -2,7 +2,7 @@
 //!
 //! See also [the manual of dsytrf](http://www.netlib.org/lapack/lapack-3.1.1/html/dsytrf.f.html)
 
-use lapack::c;
+use lapacke;
 
 use error::*;
 use layout::MatrixLayout;
@@ -55,7 +55,7 @@ impl Solveh_ for $scalar {
 
 }} // impl_solveh!
 
-impl_solveh!(f64, c::dsytrf, c::dsytri, c::dsytrs);
-impl_solveh!(f32, c::ssytrf, c::ssytri, c::ssytrs);
-impl_solveh!(c64, c::zhetrf, c::zhetri, c::zhetrs);
-impl_solveh!(c32, c::chetrf, c::chetri, c::chetrs);
+impl_solveh!(f64, lapacke::dsytrf, lapacke::dsytri, lapacke::dsytrs);
+impl_solveh!(f32, lapacke::ssytrf, lapacke::ssytri, lapacke::ssytrs);
+impl_solveh!(c64, lapacke::zhetrf, lapacke::zhetri, lapacke::zhetrs);
+impl_solveh!(c32, lapacke::chetrf, lapacke::chetri, lapacke::chetrs);

--- a/src/lapack_traits/svd.rs
+++ b/src/lapack_traits/svd.rs
@@ -1,6 +1,6 @@
 //! Singular-value decomposition
 
-use lapack::c;
+use lapacke;
 use num_traits::Zero;
 
 use error::*;
@@ -63,7 +63,7 @@ impl SVD_ for $scalar {
 
 }} // impl_svd!
 
-impl_svd!(f64, c::dgesvd);
-impl_svd!(f32, c::sgesvd);
-impl_svd!(c64, c::zgesvd);
-impl_svd!(c32, c::cgesvd);
+impl_svd!(f64, lapacke::dgesvd);
+impl_svd!(f32, lapacke::sgesvd);
+impl_svd!(c64, lapacke::zgesvd);
+impl_svd!(c32, lapacke::cgesvd);

--- a/src/lapack_traits/triangular.rs
+++ b/src/lapack_traits/triangular.rs
@@ -1,6 +1,6 @@
 //! Implement linear solver and inverse matrix
 
-use lapack::c;
+use lapacke;
 
 use super::{Transpose, UPLO, into_result};
 use error::*;
@@ -50,7 +50,7 @@ impl Triangular_ for $scalar {
 
 }} // impl_triangular!
 
-impl_triangular!(f64, c::dtrtri, c::dtrtrs);
-impl_triangular!(f32, c::strtri, c::strtrs);
-impl_triangular!(c64, c::ztrtri, c::ztrtrs);
-impl_triangular!(c32, c::ctrtri, c::ctrtrs);
+impl_triangular!(f64, lapacke::dtrtri, lapacke::dtrtrs);
+impl_triangular!(f32, lapacke::strtri, lapacke::strtrs);
+impl_triangular!(c64, lapacke::ztrtri, lapacke::ztrtrs);
+impl_triangular!(c32, lapacke::ctrtri, lapacke::ctrtrs);

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1,6 +1,6 @@
 //! Memory layout of matrices
 
-use lapack::c;
+use lapacke;
 use ndarray::*;
 
 use super::error::*;
@@ -44,10 +44,10 @@ impl MatrixLayout {
         }
     }
 
-    pub fn lapacke_layout(&self) -> c::Layout {
+    pub fn lapacke_layout(&self) -> lapacke::Layout {
         match *self {
-            MatrixLayout::C(_) => c::Layout::RowMajor,
-            MatrixLayout::F(_) => c::Layout::ColumnMajor,
+            MatrixLayout::C(_) => lapacke::Layout::RowMajor,
+            MatrixLayout::F(_) => lapacke::Layout::ColumnMajor,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,7 @@
 //!  - [generator functions](generate/index.html)
 //!  - [Scalar trait](types/trait.Scalar.html)
 
-extern crate lapack;
-extern crate lapack_sys;
+extern crate lapacke;
 extern crate num_traits;
 extern crate num_complex;
 extern crate rand;
@@ -29,8 +28,8 @@ extern crate procedurals;
 #[macro_use]
 extern crate derive_new;
 
-#[cfg(feature = "intel-mkl")]
-extern crate intel_mkl_src;
+//#[cfg(feature = "intel-mkl")]
+//extern crate intel_mkl_src;
 
 pub mod assert;
 pub mod cholesky;

--- a/src/solve.rs
+++ b/src/solve.rs
@@ -4,7 +4,7 @@
 //!
 //! Solve `A * x = b`:
 //!
-//! ```
+//! ```no_run
 //! #[macro_use]
 //! extern crate ndarray;
 //! extern crate ndarray_linalg;
@@ -28,9 +28,10 @@
 //! coefficient matrix `A`, it's faster to compute the LU factorization once at
 //! the beginning than solving directly using `A`:
 //!
-//! ```
+//! ```no_run
 //! # extern crate ndarray;
 //! # extern crate ndarray_linalg;
+//!
 //! use ndarray::prelude::*;
 //! use ndarray_linalg::*;
 //! # fn main() {

--- a/src/solveh.rs
+++ b/src/solveh.rs
@@ -7,7 +7,7 @@
 //!
 //! Solve `A * x = b`, where `A` is a Hermitian (or real symmetric) matrix:
 //!
-//! ```
+//! ```no_run
 //! #[macro_use]
 //! extern crate ndarray;
 //! extern crate ndarray_linalg;
@@ -32,7 +32,7 @@
 //! Hermitian or real symmetric coefficient matrix `A`, it's faster to compute
 //! the factorization once at the beginning than solving directly using `A`:
 //!
-//! ```
+//! ```no_run
 //! # extern crate ndarray;
 //! # extern crate ndarray_linalg;
 //! use ndarray::prelude::*;

--- a/tests/assert.rs
+++ b/tests/assert.rs
@@ -2,6 +2,8 @@
 extern crate ndarray;
 #[macro_use]
 extern crate ndarray_linalg;
+#[cfg(feature = "lapack-src")]
+extern crate lapack_src;
 
 #[test]
 fn assert() {

--- a/tests/cholesky.rs
+++ b/tests/cholesky.rs
@@ -2,6 +2,8 @@
 extern crate ndarray;
 #[macro_use]
 extern crate ndarray_linalg;
+#[cfg(feature = "lapack-src")]
+extern crate lapack_src;
 
 use ndarray::*;
 use ndarray_linalg::*;

--- a/tests/convert.rs
+++ b/tests/convert.rs
@@ -1,6 +1,8 @@
 
 extern crate ndarray;
 extern crate ndarray_linalg;
+#[cfg(feature = "lapack-src")]
+extern crate lapack_src;
 
 use ndarray::*;
 use ndarray_linalg::*;

--- a/tests/det.rs
+++ b/tests/det.rs
@@ -2,6 +2,8 @@ extern crate ndarray;
 #[macro_use]
 extern crate ndarray_linalg;
 extern crate num_traits;
+#[cfg(feature = "lapack-src")]
+extern crate lapack_src;
 
 use ndarray::*;
 use ndarray_linalg::*;

--- a/tests/deth.rs
+++ b/tests/deth.rs
@@ -2,6 +2,8 @@ extern crate ndarray;
 #[macro_use]
 extern crate ndarray_linalg;
 extern crate num_traits;
+#[cfg(feature = "lapack-src")]
+extern crate lapack_src;
 
 use ndarray::*;
 use ndarray_linalg::*;

--- a/tests/diag.rs
+++ b/tests/diag.rs
@@ -2,6 +2,8 @@
 extern crate ndarray;
 #[macro_use]
 extern crate ndarray_linalg;
+#[cfg(feature = "lapack-src")]
+extern crate lapack_src;
 
 use ndarray::*;
 use ndarray_linalg::*;

--- a/tests/eigh.rs
+++ b/tests/eigh.rs
@@ -2,6 +2,8 @@
 extern crate ndarray;
 #[macro_use]
 extern crate ndarray_linalg;
+#[cfg(feature = "lapack-src")]
+extern crate lapack_src;
 
 use ndarray::*;
 use ndarray_linalg::*;

--- a/tests/inv.rs
+++ b/tests/inv.rs
@@ -3,6 +3,8 @@ extern crate ndarray;
 #[macro_use]
 extern crate ndarray_linalg;
 extern crate num_traits;
+#[cfg(feature = "lapack-src")]
+extern crate lapack_src;
 
 use ndarray::*;
 use ndarray_linalg::*;

--- a/tests/layout.rs
+++ b/tests/layout.rs
@@ -1,6 +1,8 @@
 
 extern crate ndarray;
 extern crate ndarray_linalg;
+#[cfg(feature = "lapack-src")]
+extern crate lapack_src;
 
 use ndarray::*;
 use ndarray_linalg::*;

--- a/tests/normalize.rs
+++ b/tests/normalize.rs
@@ -3,6 +3,8 @@ extern crate ndarray;
 #[macro_use]
 extern crate ndarray_linalg;
 extern crate num_traits;
+#[cfg(feature = "lapack-src")]
+extern crate lapack_src;
 
 use ndarray::*;
 use ndarray_linalg::*;

--- a/tests/opnorm.rs
+++ b/tests/opnorm.rs
@@ -3,6 +3,8 @@ extern crate ndarray;
 #[macro_use]
 extern crate ndarray_linalg;
 extern crate num_traits;
+#[cfg(feature = "lapack-src")]
+extern crate lapack_src;
 
 use ndarray::*;
 use ndarray_linalg::*;

--- a/tests/qr.rs
+++ b/tests/qr.rs
@@ -2,6 +2,8 @@
 extern crate ndarray;
 #[macro_use]
 extern crate ndarray_linalg;
+#[cfg(feature = "lapack-src")]
+extern crate lapack_src;
 
 use ndarray::*;
 use ndarray_linalg::*;

--- a/tests/solve.rs
+++ b/tests/solve.rs
@@ -2,6 +2,8 @@ extern crate ndarray;
 #[macro_use]
 extern crate ndarray_linalg;
 extern crate num_traits;
+#[cfg(feature = "lapack-src")]
+extern crate lapack_src;
 
 use ndarray::*;
 use ndarray_linalg::*;

--- a/tests/solveh.rs
+++ b/tests/solveh.rs
@@ -3,6 +3,8 @@ extern crate ndarray;
 #[macro_use]
 extern crate ndarray_linalg;
 extern crate num_traits;
+#[cfg(feature = "lapack-src")]
+extern crate lapack_src;
 
 use ndarray::*;
 use ndarray_linalg::*;

--- a/tests/svd.rs
+++ b/tests/svd.rs
@@ -2,6 +2,8 @@
 extern crate ndarray;
 #[macro_use]
 extern crate ndarray_linalg;
+#[cfg(feature = "lapack-src")]
+extern crate lapack_src;
 
 use ndarray::*;
 use ndarray_linalg::*;

--- a/tests/trace.rs
+++ b/tests/trace.rs
@@ -1,6 +1,8 @@
 
 extern crate ndarray;
 extern crate ndarray_linalg;
+#[cfg(feature = "lapack-src")]
+extern crate lapack_src;
 
 use ndarray::*;
 use ndarray_linalg::*;

--- a/tests/triangular.rs
+++ b/tests/triangular.rs
@@ -2,6 +2,8 @@
 extern crate ndarray;
 #[macro_use]
 extern crate ndarray_linalg;
+#[cfg(feature = "lapack-src")]
+extern crate lapack_src;
 
 use ndarray::*;
 use ndarray_linalg::*;

--- a/tests/vector.rs
+++ b/tests/vector.rs
@@ -3,6 +3,8 @@ extern crate ndarray;
 #[macro_use]
 extern crate ndarray_linalg;
 extern crate num_traits;
+#[cfg(feature = "lapack-src")]
+extern crate lapack_src;
 
 use ndarray::*;
 use ndarray_linalg::*;

--- a/wercker.yml
+++ b/wercker.yml
@@ -4,13 +4,13 @@ test-openblas:
   steps:
     - script:
       name: test OpenBLAS backend
-      code: cargo test --no-default-features --features=openblas-static
+      code: cargo test --no-default-features --features=openblas
 
 test-netlib:
   steps:
     - script:
       name: test NetLib backend
-      code: cargo test --no-default-features --features=netlib-static
+      code: cargo test --no-default-features --features=netlib
 
 test-intel-mkl:
   steps:


### PR DESCRIPTION
Adapt for changes in the upstream crate (was `lapack`, now C wrappers are in `lapacke`) and do not link to an LAPACKE implementation in this library. Linking to an LAPACKE implementation now starts to be user's responsibility and allows for more flexibility than with Cargo features, for example, selecting different backend for different OS.

Relevant `lapack` commit: https://github.com/blas-lapack-rs/lapack/commit/5516490f5636aeaf25f82725aea643dddd8a4337
Also includes minor changes from #94.