### PR TITLE
Add missing backend dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,3 +55,8 @@ version = "0.5.3"
 features = ["static", "cblas", "lapacke"]
 default-features = false
 optional = true
+
+# Use OpenBLAS backend for examples, tests, and benchmarks.
+[dev-dependencies.blas-src]
+version = "0.1"
+features = ["openblas"]


### PR DESCRIPTION
Since the default feature set of `ndarray-linalg` is empty, examples and tests were unable to build since no backend was selected. This commit adds a dev-dependency to use the OpenBLAS backend.

Steps to reproduce the issue that this PR fixes:

```
$ git clone https://github.com/termoshtt/ndarray-linalg.git
$ cd ndarray-linalg
$ cargo test
...
error: linking with `cc` failed: exit code: 1
...
error: Could not compile `ndarray-linalg`.
...
```

I'm surprised this hasn't come up earlier. Are other people able to run `cargo test` without this PR?