### PR TITLE
Switch from failure::Fail to std's Error trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ serde-1    = ["ndarray/serde-1", "num-complex/serde"]
 lapacke = "0.2"
 num-traits  = "0.2"
 rand = "0.5"
-failure = "0.1"
 
 [dependencies.num-complex]
 version = "0.2"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,35 +1,49 @@
 //! Define Errors
 
 use ndarray::{Ixs, ShapeError};
+use std::error;
+use std::fmt;
 
 pub type Result<T> = ::std::result::Result<T, LinalgError>;
 
 /// Master Error type of this crate
-#[derive(Fail, Debug)]
+#[derive(Debug)]
 pub enum LinalgError {
     /// Matrix is not square
-    #[fail(display = "Not square: rows({}) != cols({})", rows, cols)]
     NotSquare { rows: i32, cols: i32 },
-
     /// LAPACK subroutine returns non-zero code
-    #[fail(display = "LAPACK: return_code = {}", return_code)]
-    LapackFailure { return_code: i32 },
-
+    Lapack { return_code: i32 },
     /// Strides of the array is not supported
-    #[fail(display = "invalid stride: s0={}, s1={}", s0, s1)]
     InvalidStride { s0: Ixs, s1: Ixs },
-
     /// Memory is not aligned continously
-    #[fail(display = "Memory is not contiguous")]
-    MemoryNotCont {},
-
+    MemoryNotCont,
     /// Strides of the array is not supported
-    #[fail(display = "Shape Error: {}", error)]
-    ShapeFailure { error: ShapeError },
+    Shape(ShapeError),
+}
+
+impl fmt::Display for LinalgError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            LinalgError::NotSquare { rows, cols } => write!(f, "Not square: rows({}) != cols({})", rows, cols),
+            LinalgError::Lapack { return_code } => write!(f, "LAPACK: return_code = {}", return_code),
+            LinalgError::InvalidStride { s0, s1 } => write!(f, "invalid stride: s0={}, s1={}", s0, s1),
+            LinalgError::MemoryNotCont => write!(f, "Memory is not contiguous"),
+            LinalgError::Shape(err) => write!(f, "Shape Error: {}", err),
+        }
+    }
+}
+
+impl error::Error for LinalgError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            LinalgError::Shape(err) => Some(err),
+            _ => None,
+        }
+    }
 }
 
 impl From<ShapeError> for LinalgError {
     fn from(error: ShapeError) -> LinalgError {
-        LinalgError::ShapeFailure { error }
+        LinalgError::Shape(error)
     }
 }

--- a/src/lapack_traits/mod.rs
+++ b/src/lapack_traits/mod.rs
@@ -34,7 +34,7 @@ pub fn into_result<T>(return_code: i32, val: T) -> Result<T> {
     if return_code == 0 {
         Ok(val)
     } else {
-        Err(LinalgError::LapackFailure { return_code })
+        Err(LinalgError::Lapack { return_code })
     }
 }
 

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -128,7 +128,7 @@ where
     fn as_allocated(&self) -> Result<&[A]> {
         Ok(self
             .as_slice_memory_order()
-            .ok_or_else(|| LinalgError::MemoryNotCont {})?)
+            .ok_or_else(|| LinalgError::MemoryNotCont)?)
     }
 }
 
@@ -139,6 +139,6 @@ where
     fn as_allocated_mut(&mut self) -> Result<&mut [A]> {
         Ok(self
             .as_slice_memory_order_mut()
-            .ok_or_else(|| LinalgError::MemoryNotCont {})?)
+            .ok_or_else(|| LinalgError::MemoryNotCont)?)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,6 @@ extern crate lapacke;
 extern crate num_complex;
 extern crate num_traits;
 extern crate rand;
-#[macro_use]
-extern crate failure;
 #[macro_use(s)]
 extern crate ndarray;
 

--- a/src/solve.rs
+++ b/src/solve.rs
@@ -427,7 +427,7 @@ where
         self.ensure_square()?;
         match self.factorize() {
             Ok(fac) => fac.sln_det(),
-            Err(LinalgError::LapackFailure { return_code }) if return_code > 0 => {
+            Err(LinalgError::Lapack { return_code }) if return_code > 0 => {
                 // The determinant is zero.
                 Ok((A::zero(), A::Real::neg_infinity()))
             }
@@ -445,7 +445,7 @@ where
         self.ensure_square()?;
         match self.factorize_into() {
             Ok(fac) => fac.sln_det_into(),
-            Err(LinalgError::LapackFailure { return_code }) if return_code > 0 => {
+            Err(LinalgError::Lapack { return_code }) if return_code > 0 => {
                 // The determinant is zero.
                 Ok((A::zero(), A::Real::neg_infinity()))
             }

--- a/src/solveh.rs
+++ b/src/solveh.rs
@@ -421,7 +421,7 @@ where
     fn sln_deth(&self) -> Result<(A::Real, A::Real)> {
         match self.factorizeh() {
             Ok(fac) => Ok(fac.sln_deth()),
-            Err(LinalgError::LapackFailure { return_code }) if return_code > 0 => {
+            Err(LinalgError::Lapack { return_code }) if return_code > 0 => {
                 // Determinant is zero.
                 Ok((A::Real::zero(), A::Real::neg_infinity()))
             }
@@ -445,7 +445,7 @@ where
     fn sln_deth_into(self) -> Result<(A::Real, A::Real)> {
         match self.factorizeh_into() {
             Ok(fac) => Ok(fac.sln_deth_into()),
-            Err(LinalgError::LapackFailure { return_code }) if return_code > 0 => {
+            Err(LinalgError::Lapack { return_code }) if return_code > 0 => {
                 // Determinant is zero.
                 Ok((A::Real::zero(), A::Real::neg_infinity()))
             }


### PR DESCRIPTION
#118 simplified the `LinalgError` enum but also changed it from implementing `Error` to implementing `Fail`. This PR keeps the simplifications but changes it to implement `Error` again. (I also renamed the `LapackFailure` variant to `Lapack`, renamed the `ShapeFailure` variant to `Shape` and changed it to a tuple, and removed the braces from `MemoryNotCont`.) IMO this is better for a few reasons:

1. `failure` is ["experimental"](https://docs.rs/failure/0.1.5/failure/) and ["currently evolving"](https://github.com/rust-lang-nursery/failure#evolution), so while it may be fine for an end-user application, I don't think we should use it for a library like `ndarray-linalg`.
2. The standard library's `Error` is being updated based on the `failure` experiment to resolve most of the issues with the old version of `Error`. ([RFC 2504](https://github.com/rust-lang/rfcs/blob/master/text/2504-fix-error.md)) In stable, the [`.source()`](https://doc.rust-lang.org/std/error/trait.Error.html#method.source) method has already been added, [`.cause()`](https://doc.rust-lang.org/std/error/trait.Error.html#method.cause) is planned to be deprecated in 1.33, and [`.description()`](https://doc.rust-lang.org/std/error/trait.Error.html#method.description) is "soft-deprecated".
3. It's annoying to have to call [`.compat()`](https://docs.rs/failure/0.1.5/failure/trait.Fail.html#method.compat) to get something that implements `Error`.