### PR TITLE
Fix off-by-one in superb allocation for svd

### DIFF
--- a/src/lapack_traits/svd.rs
+++ b/src/lapack_traits/svd.rs
@@ -50,7 +50,7 @@ macro_rules! impl_svd {
                     (FlagSVD::No, 0, Vec::new())
                 };
                 let mut s = vec![Self::Real::zero(); k as usize];
-                let mut superb = vec![Self::Real::zero(); (k - 2) as usize];
+                let mut superb = vec![Self::Real::zero(); (k - 1) as usize];
                 let info = $gesvd(
                     l.lapacke_layout(),
                     ju as u8,


### PR DESCRIPTION
valgrind reports errors in SVD. There is very little documentation on
the 'superb' argument of *gesvd. Intel MKL documentation states that its
size should be min(m, n) - 2. However, in the MKL examples min(m, n) - 1 is used:

https://software.intel.com/sites/products/documentation/doclib/mkl_sa/11/mkl_lapack_examples/lapacke_dgesvd_row.c.htm

Changing the size of superb to min(m, n) -1 resolved the memory error in
valgrind.

---

Additional PR comments: we observed fatal errors when performing SVD on a 300x300 matrix:

~~~
*** Error in `/home/daniel/git/rust2vec/target/release/r2v-quantize': free(): invalid next size (normal): 0x000055b6d0ae0120 ***
======= Backtrace: =========
[...]
/lib/x86_64-linux-gnu/libc.so.6(cfree+0x4c)[0x7f2d95ed353c]
/home/daniel/git/rust2vec/target/release/r2v-quantize(_ZN64_$LT$f32$u20$as$u20$ndarray_linalg..lapack_traits..svd..SVD_$GT$3svd17h13390d27664951bcE+0x34f)[0x55b6cc5a414f]
~~~

So I used valgrind on the SVD unit tests of `ndarray-linalg`, which reports memory errors:

~~~
==30471== Invalid write of size 8                                         
==30471==    at 0x535F08B: LAPACKE_dgesvd (in /home/daniel/intel/compilers_and_libraries_2017.0.098/linux/mkl/lib/intel64_lin/libmkl_intel_lp64.so)
==30471==    by 0x1970CE: lapacke::dgesvd (lib.rs:5228)                                                                                                               
==30471==    by 0x19523D: <f64 as ndarray_linalg::lapack_traits::svd::SVD_>::svd (svd.rs:54)                                                    
==30471==    by 0x12C9FE: <ndarray::ArrayBase<S, ndarray::dimension::dim::Dim<[usize; _]>> as ndarray_linalg::svd::SVDInplace>::svd_inplace (svd.rs:76)
==30471==    by 0x12C722: <ndarray::ArrayBase<S, ndarray::dimension::dim::Dim<[usize; _]>> as ndarray_linalg::svd::SVDInto>::svd_into (svd.rs:46)       
==30471==    by 0x12C6D7: <ndarray::ArrayBase<S, ndarray::dimension::dim::Dim<[usize; _]>> as ndarray_linalg::svd::SVD>::svd (svd.rs:61)           
==30471==    by 0x144327: svd::test (svd.rs:12)                           
==30471==    by 0x144D8B: svd::svd_4x3 (svd.rs:52)                                          
==30471==    by 0x156739: svd::svd_4x3::{{closure}} (svd.rs:50)       
==30471==    by 0x14BC6D: core::ops::function::FnOnce::call_once (function.rs:238)
[...]
==30471==  Address 0xa1e4ee8 is 0 bytes after a block of size 8 alloc'd                                                                                
==30471==    at 0x4C31B25: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)                                                                            
==30471==    by 0x1D895B: alloc::alloc::alloc_zeroed (alloc.rs:151)                                                                             
==30471==    by 0x1D87E1: <alloc::alloc::Global as core::alloc::Alloc>::alloc_zeroed (alloc.rs:178)                                        
==30471==    by 0x1D351D: <alloc::raw_vec::RawVec<T, A>>::allocate_in (raw_vec.rs:104)                                                                  
==30471==    by 0x196588: <alloc::raw_vec::RawVec<T>>::with_capacity_zeroed (raw_vec.rs:156)                                                       
==30471==    by 0x1963AC: <T as alloc::vec::SpecFromElem>::from_elem (vec.rs:1548)
==30471==    by 0x1964B6: alloc::vec::from_elem (vec.rs:1509)                               
==30471==    by 0x194FD0: <f64 as ndarray_linalg::lapack_traits::svd::SVD_>::svd (svd.rs:53)
==30471==    by 0x12C9FE: <ndarray::ArrayBase<S, ndarray::dimension::dim::Dim<[usize; _]>> as ndarray_linalg::svd::SVDInplace>::svd_inplace (svd.rs:76)
==30471==    by 0x12C722: <ndarray::ArrayBase<S, ndarray::dimension::dim::Dim<[usize; _]>> as ndarray_linalg::svd::SVDInto>::svd_into (svd.rs:46)
==30471==    by 0x12C6D7: <ndarray::ArrayBase<S, ndarray::dimension::dim::Dim<[usize; _]>> as ndarray_linalg::svd::SVD>::svd (svd.rs:61)
~~~

After this change, these memory errors are gone.

Interestingly, SVD did not fail for use before, but I guess the error only showed itself after upgrading to Rust 1.32, which switches from jemalloc to the system allocator.