### PR TITLE
WIP: Check null array

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,8 @@ pub enum LinalgError {
     InvalidStride { s0: Ixs, s1: Ixs },
     /// Memory is not aligned continously
     MemoryNotCont,
+    /// Array is null (0-sized)
+    NullArray,
     /// Strides of the array is not supported
     Shape(ShapeError),
 }
@@ -28,6 +30,7 @@ impl fmt::Display for LinalgError {
             LinalgError::Lapack { return_code } => write!(f, "LAPACK: return_code = {}", return_code),
             LinalgError::InvalidStride { s0, s1 } => write!(f, "invalid stride: s0={}, s1={}", s0, s1),
             LinalgError::MemoryNotCont => write!(f, "Memory is not contiguous"),
+            LinalgError::NullArray => write!(f, "Array is null (0-sized)"),
             LinalgError::Shape(err) => write!(f, "Shape Error: {}", err),
         }
     }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -90,6 +90,9 @@ where
     type Elem = A;
 
     fn layout(&self) -> Result<MatrixLayout> {
+        if self.len() == 0 {
+            return Err(LinalgError::NullArray);
+        }
         let shape = self.shape();
         let strides = self.strides();
         if shape[0] == strides[1] as usize {
@@ -126,9 +129,7 @@ where
     }
 
     fn as_allocated(&self) -> Result<&[A]> {
-        Ok(self
-            .as_slice_memory_order()
-            .ok_or_else(|| LinalgError::MemoryNotCont)?)
+        Ok(self.as_slice_memory_order().ok_or_else(|| LinalgError::MemoryNotCont)?)
     }
 }
 


### PR DESCRIPTION
Resolve #132 

- LAPACK does not accept `LDA=0` (but `N` can be `0`)
- Check array is empty before sending to LAPACK interface
  - Add `LinalgError::NullArray`
