### PR TITLE
Fix singular tests

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -51,6 +51,9 @@ where
 }
 
 /// Random Hermite Positive-definite matrix
+///
+/// - Eigenvalue of matrix must be larger than 1 (thus non-singular)
+///
 pub fn random_hpd<A, S>(n: usize) -> ArrayBase<S, Ix2>
 where
     A: RandNormal + Conjugate + LinalgScalar,
@@ -58,7 +61,7 @@ where
 {
     let a: Array2<A> = random((n, n));
     let ah: Array2<A> = conjugate(&a);
-    replicate(&ah.dot(&a))
+    ArrayBase::eye(n) + &ah.dot(&a)
 }
 
 /// construct matrix from diag

--- a/tests/solve.rs
+++ b/tests/solve.rs
@@ -23,7 +23,7 @@ fn solve_random_t() {
 fn rcond() {
     macro_rules! rcond {
         ($elem:ty, $rows:expr, $atol:expr) => {
-            let a: Array2<$elem> = random(($rows, $rows));
+            let a: Array2<$elem> = random_hpd($rows);
             let rcond = 1. / (a.opnorm_one().unwrap() * a.inv().unwrap().opnorm_one().unwrap());
             assert_aclose!(a.rcond().unwrap(), rcond, $atol);
             assert_aclose!(a.rcond_into().unwrap(), rcond, $atol);


### PR DESCRIPTION
Resolve #91

Change `random_hpd` behavior

- Eigenvalue of the matrix must be larger than 1 (returns `1 + A^T A` instead of `A^T A`)
- Use `random_hpd` in `rcond` test